### PR TITLE
Fix key bindings

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,4 +1,4 @@
 <Bindings>
-    <Binding name="WOWHEAD_QUICK_LINK_NAME" header="WOWHEAD_QUICK_LINK_HEADER" category="ADDONS" runOnUp="true" default="CTRL-C">RunWowheadQuickLink()</Binding>
-    <Binding name="WOWHEAD_QUICK_LINK_RAIDERIO_NAME" category="ADDONS" runOnUp="true" default="CTRL-SHIFT-C">RunAlternativeQuickLink()</Binding>
+    <Binding name="WOWHEAD_QUICK_LINK_NAME" header="WOWHEAD_QUICK_LINK_HEADER" category="ADDONS">RunWowheadQuickLink()</Binding>
+    <Binding name="WOWHEAD_QUICK_LINK_RAIDERIO_NAME" category="ADDONS">RunAlternativeQuickLink()</Binding>
 </Bindings>

--- a/WowheadQuickLinkConfig.lua
+++ b/WowheadQuickLinkConfig.lua
@@ -18,7 +18,12 @@ frame:SetScript("OnEvent", function(self, event, arg1)
             -- first value is the name attribute of each from Bindings.xml
             HandleDefaultBindings("WOWHEAD_QUICK_LINK_NAME", "CTRL-C")
             HandleDefaultBindings("WOWHEAD_QUICK_LINK_RAIDERIO_NAME", "CTRL-SHIFT-C")
-            SaveBindings(GetCurrentBindingSet())
+
+            if IsClassic() then
+                AttemptToSaveBindings(GetCurrentBindingSet())
+            else
+                SaveBindings(GetCurrentBindingSet())
+            end
 
             -- prevent setup from running again
             WowheadQuickLinkCfg.defaultBindingsSet = true

--- a/WowheadQuickLinkConfig.lua
+++ b/WowheadQuickLinkConfig.lua
@@ -6,12 +6,37 @@ frame:SetScript("OnEvent", function(self, event, arg1)
     if event == "ADDON_LOADED" and arg1 == "WowheadQuickLink" then
         if WowheadQuickLinkCfg == nil then
             WowheadQuickLinkCfg = {
-                prefix = "", 
+                prefix = "",
                 suffix = ""
             }
         end
+
+        -- check if binding setup has run before
+        if WowheadQuickLinkCfg.defaultBindingsSet == nil then
+            -- hasn't run before, so run it
+
+            -- first value is the name attribute of each from Bindings.xml
+            HandleDefaultBindings("WOWHEAD_QUICK_LINK_NAME", "CTRL-C")
+            HandleDefaultBindings("WOWHEAD_QUICK_LINK_RAIDERIO_NAME", "CTRL-SHIFT-C")
+            SaveBindings(GetCurrentBindingSet())
+
+            -- prevent setup from running again
+            WowheadQuickLinkCfg.defaultBindingsSet = true
+        end
     end
 end)
+
+function HandleDefaultBindings(binding_name, default_key)
+    -- get existing binding info
+    local bind1, bind2 = GetBindingKey(binding_name)
+    local action = GetBindingAction(default_key)
+
+    -- check if binds have been set by the user or the default key is used anywhere else
+    if bind1 == nil and bind2 == nil and action == "" then
+        -- neither bind has been set by the user and the default key isn't in use, so set the default key
+        SetBinding(default_key, binding_name)
+    end
+end
 
 
 function IsClassic()

--- a/WowheadQuickLinkConfig.lua
+++ b/WowheadQuickLinkConfig.lua
@@ -1,6 +1,7 @@
 local addonName, nameSpace = ...
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("ADDON_LOADED")
+frame:RegisterEvent("PLAYER_LOGIN")
 
 frame:SetScript("OnEvent", function(self, event, arg1)
     if event == "ADDON_LOADED" and arg1 == "WowheadQuickLink" then
@@ -10,9 +11,9 @@ frame:SetScript("OnEvent", function(self, event, arg1)
                 suffix = ""
             }
         end
-
+    elseif event == "PLAYER_LOGIN" then
         -- check if binding setup has run before
-        if WowheadQuickLinkCfg.defaultBindingsSet == nil then
+        if WowheadQuickLinkCfg.default_bindings_set == nil then
             -- hasn't run before, so run it
 
             -- first value is the name attribute of each from Bindings.xml
@@ -26,8 +27,10 @@ frame:SetScript("OnEvent", function(self, event, arg1)
             end
 
             -- prevent setup from running again
-            WowheadQuickLinkCfg.defaultBindingsSet = true
+            WowheadQuickLinkCfg.default_bindings_set = true
         end
+
+        frame:UnregisterEvent("PLAYER_LOGIN")
     end
 end)
 

--- a/WowheadQuickLinkStrategies.lua
+++ b/WowheadQuickLinkStrategies.lua
@@ -2,16 +2,16 @@ local addonName, nameSpace = ...
 nameSpace.strategies = {}
 nameSpace.altStrategies = {}
 local strategies = {
-    wowhead = {}, 
-    wowheadAzEs = {}, 
+    wowhead = {},
+    wowheadAzEs = {},
     armory = {}
 }
 local tooltipStates = {}
 local regions = {
-    [1] = "us", 
-    [2] = "kr", 
-    [3] = "eu", 
-    [4] = "tw", 
+    [1] = "us",
+    [2] = "kr",
+    [3] = "eu",
+    [4] = "tw",
     [5] = "cn"
 }
 
@@ -20,7 +20,7 @@ function nameSpace.strategies.GetWowheadUrl(dataSources)
     for _, strategy in pairs(strategies.wowhead) do
         local id, type = strategy(dataSources)
         if id and type then
-            return "Wowhead " .. type:sub(1, 1):upper() .. type:sub(2), 
+            return "Wowhead " .. type:sub(1, 1):upper() .. type:sub(2),
                 string.format(nameSpace.baseWowheadUrl, WowheadQuickLinkCfg.prefix, type, id, WowheadQuickLinkCfg.suffix)
         end
     end
@@ -31,7 +31,7 @@ function nameSpace.strategies.GetWowheadAzEsUrl(dataSources)
     for _, strategy in pairs(strategies.wowheadAzEs) do
         local id = strategy(dataSources)
         if id then
-            return "Wowhead Azerite Essence", 
+            return "Wowhead Azerite Essence",
                 string.format(nameSpace.baseWowheadAzEsUrl, WowheadQuickLinkCfg.prefix, id, WowheadQuickLinkCfg.suffix)
         end
     end
@@ -221,7 +221,7 @@ end
 
 
 function strategies.wowhead.GetItemFromAuctionHouseClassic(data)
-    if not IsClassic() and not data.focus.itemIndex and (not data.focus:GetParent() or not data.focus:GetParent().itemIndex) then return end
+    if not IsClassic() or (not data.focus.itemIndex and (not data.focus:GetParent() or not data.focus:GetParent().itemIndex)) then return end
     local index = data.focus.itemIndex or data.focus:GetParent().itemIndex
     local link = GetAuctionItemLink("list", index)
     local id, type = GetFromLink(link)


### PR DESCRIPTION
Just a note: This is my first time ever using Lua or doing anything with a WoW addon.

Key bindings set with `default="key"` in `Bindings.xml` aren't persisted after a UI reload, so I wrote this code to work around that. It saves them as actual bindings as long as:

* the user hasn't previously set their own bindings for the addon, and
* the default bindings aren't already used anywhere else.

I don't know if you'd like to display a message if either of those is false (so bindings aren't set), but I didn't add them because presumably the bindings have never worked if that's the case. I know the comments are a little gratuitous, let me know if you want those changed (or you can change them).

I also removed `runOnUp="true"` from `Bindings.xml`, because that attribute causes the action to run both when you press the binding and when you release, so the handlers were unnecessarily running twice ([source](https://wow.gamepedia.com/Creating_key_bindings#Specifying_bindings)).