### PR TITLE
Fix bug, update TOC

### DIFF
--- a/WowheadQuickLink.toc
+++ b/WowheadQuickLink.toc
@@ -1,5 +1,5 @@
-## Interface: 90001
-## Version: 2.7.0
+## Interface: 90002
+## Version: 2.9.3
 ## Title: Wowhead Quick Link
 ## Notes: Mouse over and press CTRL-C on (almost) anything to generate a Wowhead link.
 ## Author: Blur

--- a/WowheadQuickLinkStrategies.lua
+++ b/WowheadQuickLinkStrategies.lua
@@ -268,7 +268,7 @@ end
 function strategies.wowhead.GetCurrencyInTabFromFocus(data)
     if data.focus.isUnused == nil and (not data.focus:GetParent() or data.focus:GetParent().isUnused == nil) then return end
     local index = data.focus.index or data.focus:GetParent().index
-    local link = GetCurrencyListLink(index)
+    local link = C_CurrencyInfo.GetCurrencyListLink(index)
     return GetFromLink(link)
 end
 

--- a/WowheadQuickLinkStrategies.lua
+++ b/WowheadQuickLinkStrategies.lua
@@ -20,7 +20,13 @@ function nameSpace.strategies.GetWowheadUrl(dataSources)
     for _, strategy in pairs(strategies.wowhead) do
         local id, type = strategy(dataSources)
         if id and type then
-            return "Wowhead " .. type:sub(1, 1):upper() .. type:sub(2),
+            local typeStr
+            if type == "npc" then
+                typeStr = "NPC"
+            else
+                typeStr = type:sub(1, 1):upper() .. type:sub(2)
+            end
+            return "Wowhead " .. typeStr,
                 string.format(nameSpace.baseWowheadUrl, WowheadQuickLinkCfg.prefix, type, id, WowheadQuickLinkCfg.suffix)
         end
     end
@@ -178,7 +184,7 @@ function strategies.wowhead.GetNpcFromTooltip(data)
     if not data.tooltip then return end
     local _, unit = data.tooltip:GetUnit()
     if not unit then return end
-    return select(6, strsplit("-", UnitGUID(unit))), "NPC"
+    return select(6, strsplit("-", UnitGUID(unit))), "npc"
 end
 
 
@@ -203,20 +209,20 @@ function strategies.wowhead.GetBattlePetFromFocus(data)
     else
         id = select(4, C_PetJournal.GetPetInfoBySpeciesID(petId))
     end
-    return id, "NPC"
+    return id, "npc"
 end
 
 
 function strategies.wowhead.GetBattlePetFromFloatingTooltip(data)
     if not data.focus.speciesID then return end
-    return select(4, C_PetJournal.GetPetInfoBySpeciesID(data.focus.speciesID)), "NPC"
+    return select(4, C_PetJournal.GetPetInfoBySpeciesID(data.focus.speciesID)), "npc"
 end
 
 
 function strategies.wowhead.GetBattlePetFromAuctionHouse(data)
     if not data.focus.itemKey and (not data.focus.GetRowData or not data.focus:GetRowData().itemKey) then return end
     local itemKey = data.focus.itemKey or data.focus:GetRowData().itemKey
-    return select(4, C_PetJournal.GetPetInfoBySpeciesID(itemKey.battlePetSpeciesID)), "NPC"
+    return select(4, C_PetJournal.GetPetInfoBySpeciesID(itemKey.battlePetSpeciesID)), "npc"
 end
 
 
@@ -227,7 +233,7 @@ function strategies.wowhead.GetItemFromAuctionHouseClassic(data)
     local id, type = GetFromLink(link)
     if type == "battlepet" then
         id = select(4, C_PetJournal.GetPetInfoBySpeciesID(id))
-        type = "NPC"
+        type = "npc"
     end
     return id, type
 end

--- a/WowheadQuickLinkStrategies.lua
+++ b/WowheadQuickLinkStrategies.lua
@@ -178,7 +178,7 @@ function strategies.wowhead.GetNpcFromTooltip(data)
     if not data.tooltip then return end
     local _, unit = data.tooltip:GetUnit()
     if not unit then return end
-    return select(6, strsplit("-", UnitGUID(unit))), "npc"
+    return select(6, strsplit("-", UnitGUID(unit))), "NPC"
 end
 
 
@@ -203,20 +203,20 @@ function strategies.wowhead.GetBattlePetFromFocus(data)
     else
         id = select(4, C_PetJournal.GetPetInfoBySpeciesID(petId))
     end
-    return id, "npc"
+    return id, "NPC"
 end
 
 
 function strategies.wowhead.GetBattlePetFromFloatingTooltip(data)
     if not data.focus.speciesID then return end
-    return select(4, C_PetJournal.GetPetInfoBySpeciesID(data.focus.speciesID)), "npc"
+    return select(4, C_PetJournal.GetPetInfoBySpeciesID(data.focus.speciesID)), "NPC"
 end
 
 
 function strategies.wowhead.GetBattlePetFromAuctionHouse(data)
     if not data.focus.itemKey and (not data.focus.GetRowData or not data.focus:GetRowData().itemKey) then return end
     local itemKey = data.focus.itemKey or data.focus:GetRowData().itemKey
-    return select(4, C_PetJournal.GetPetInfoBySpeciesID(itemKey.battlePetSpeciesID)), "npc"
+    return select(4, C_PetJournal.GetPetInfoBySpeciesID(itemKey.battlePetSpeciesID)), "NPC"
 end
 
 
@@ -227,7 +227,7 @@ function strategies.wowhead.GetItemFromAuctionHouseClassic(data)
     local id, type = GetFromLink(link)
     if type == "battlepet" then
         id = select(4, C_PetJournal.GetPetInfoBySpeciesID(id))
-        type = "npc"
+        type = "NPC"
     end
     return id, type
 end


### PR DESCRIPTION
Hello! I noticed the addon wasn't updated for 9.0.2 according to WoW, so I made this PR to fix that. While I was in there, I also fixed #14 (`GetCurrencyListLink` was renamed to [`C_CurrencyInfo.GetCurrencyListLink`](https://wow.gamepedia.com/API_C_CurrencyInfo.GetCurrencyListLink) in 9.0.1).

Finally, I tweaked `nameSpace.strategies.GetWowheadUrl` to display the "NPC" type correctly in the header because it annoyed me that it displayed as "Npc". I can remove this if you don't want to deal with it, no big deal.

Thank you!