### PR TITLE
Updates for BCC

### DIFF
--- a/WowheadQuickLink-BCC.toc
+++ b/WowheadQuickLink-BCC.toc
@@ -1,4 +1,4 @@
-## Interface: 90002
+## Interface: 20501
 ## Version: 2.10.1
 ## Title: Wowhead Quick Link
 ## Notes: Mouse over and press CTRL-C on (almost) anything to generate a Wowhead link.

--- a/WowheadQuickLink-Classic.toc
+++ b/WowheadQuickLink-Classic.toc
@@ -1,4 +1,4 @@
-## Interface: 90002
+## Interface: 11307
 ## Version: 2.10.1
 ## Title: Wowhead Quick Link
 ## Notes: Mouse over and press CTRL-C on (almost) anything to generate a Wowhead link.

--- a/WowheadQuickLink.lua
+++ b/WowheadQuickLink.lua
@@ -1,7 +1,12 @@
 local addonName, nameSpace = ...
-nameSpace.baseWowheadUrl = "https://%swowhead.com/%s=%s%s"
+if IsRetail() then
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/%s=%s%s"
+end
 if IsClassic() then
     nameSpace.baseWowheadUrl = "https://%sclassic.wowhead.com/%s=%s%s"
+end
+if IsBCC() then
+    nameSpace.baseWowheadUrl = "https://%stbc.wowhead.com/%s=%s%s"
 end
 nameSpace.baseWowheadAzEsUrl = "https://%swowhead.com/azerite-essence/%s%s"
 nameSpace.baseArmoryUrl = "https://worldofwarcraft.com/%s/character/%s/%s"
@@ -44,7 +49,7 @@ end
 
 StaticPopupDialogs["WowheadQuickLinkUrl"] = {
     text = popupText,
-    button1 = "Close", 
+    button1 = "Close",
     OnShow = function(self, data)
         local function HidePopup(self) self:GetParent():Hide() end
         self.editBox:SetScript("OnEscapePressed", HidePopup)
@@ -55,11 +60,11 @@ StaticPopupDialogs["WowheadQuickLinkUrl"] = {
         self.editBox:SetMaxLetters(0)
         self.editBox:SetText(data)
         self.editBox:HighlightText()
-    end, 
-    hasEditBox = true, 
-    editBoxWidth = 240, 
-    timeout = 0, 
-    whileDead = true, 
-    hideOnEscape = true, 
-    preferredIndex = 3, 
+    end,
+    hasEditBox = true,
+    editBoxWidth = 240,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
 }

--- a/WowheadQuickLinkConfig.lua
+++ b/WowheadQuickLinkConfig.lua
@@ -47,8 +47,18 @@ function HandleDefaultBindings(binding_name, default_key)
 end
 
 
+function IsRetail()
+    return WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+end
+
+
 function IsClassic()
-    return select(4, GetBuildInfo()) < 20000
+    return WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+end
+
+
+function IsBCC()
+    return WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
 end
 
 


### PR DESCRIPTION
Finally got around to updating this for BCC. Fixes #16.

- Now uses [`WOW_PROJECT_ID`](https://wowpedia.fandom.com/wiki/WOW_PROJECT_ID) to check game version
- Split .toc into three files to support all three game versions ([docs](https://wowpedia.fandom.com/wiki/TOC_format#Basic_rules))
- Uses `tbc` subdomain for BCC
- Fixes `GetQuestFromClassicLogFocus` matching too many focuses, it should now match only the classic quest log
- Adds support for the Questie tracker _(I know you probably don't want to support a ton of addons, but I figure Questie is used by virtually everyone playing Classic/BCC so it makes sense to support that at least)_
- Removes Raider.io and armory support from classic/BCC, though the keybind remains in the menu because there doesn't seem to be a way to remove it only for them