### PR TITLE
Fix Classic/TBC compatibility issues

### DIFF
--- a/WowheadQuickLink.lua
+++ b/WowheadQuickLink.lua
@@ -5,6 +5,9 @@ end
 if IsClassic() then
     nameSpace.baseWowheadUrl = "https://%swowhead.com/classic/%s=%s%s"
 end
+if IsBCC() then
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/tbc/%s=%s%s"
+end
 if IsMop() then
     nameSpace.baseWowheadUrl = "https://%swowhead.com/mop-classic/%s=%s%s"
 end
@@ -58,13 +61,11 @@ StaticPopupDialogs["WowheadQuickLinkUrl"] = {
     button1 = "Close",
     OnShow = function(self, data)
         local function HidePopup(self) self:GetParent():Hide() end
-        local editBox
+        
+        -- Changed from "if (IsRetail() or IsMop() or IsClassic()) then" to this to make it version agnostic
+        local editBox = self.EditBox or self.editBox
+        if not editBox then return end
 
-        if (IsRetail() or IsMop() or IsClassic()) then
-            editBox = self.EditBox
-        else
-            editBox = self.editBox
-        end
         editBox:SetScript("OnEscapePressed", HidePopup)
         editBox:SetScript("OnEnterPressed", HidePopup)
         editBox:SetScript("OnKeyUp", function(self, key)

--- a/WowheadQuickLink.toc
+++ b/WowheadQuickLink.toc
@@ -1,6 +1,7 @@
 ## Interface: 110200
-## Interface-Mists: 50500
 ## Interface-Classic: 11507
+## Interface-BCC: 20505
+## Interface-Mists: 50500
 ## Version: 2.16.10
 ## Title: Wowhead Quick Link
 ## Notes: Mouse over and press CTRL-C on (almost) anything to generate a Wowhead link.

--- a/WowheadQuickLinkConfig.lua
+++ b/WowheadQuickLinkConfig.lua
@@ -53,6 +53,11 @@ function IsClassic()
 end
 
 
+function IsBCC()
+    return WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
+end
+
+
 function IsMop()
     return WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC
 end

--- a/WowheadQuickLinkStrategies.lua
+++ b/WowheadQuickLinkStrategies.lua
@@ -221,7 +221,7 @@ function strategies.wowhead.GetFromMistsWatchTitleFocus(data)
 end
 
 function strategies.wowhead.GetQuestFromClassicLogTitleFocus(data)
-    if not (IsClassic() and CheckFrameName("QuestLogTitle%d+", data) and not data.focus.isHeader) then return end
+    if not ((IsClassic() or IsBCC()) and CheckFrameName("QuestLogTitle%d+", data) and not data.focus.isHeader) then return end
     local questIndex = data.focus:GetID()
     local _, _, _, _, _, _, _, questID = GetQuestLogTitle(questIndex)
     if questID == 0 then return end
@@ -229,12 +229,12 @@ function strategies.wowhead.GetQuestFromClassicLogTitleFocus(data)
 end
 
 function strategies.wowhead.GetQuestFromQuestieTracker(data)
-    if not ((IsClassic() or IsMop()) and data.focus.Quest and type(data.focus.Quest) == "table") then return end
+    if not ((IsClassic() or IsBCC() or IsMop()) and data.focus.Quest and type(data.focus.Quest) == "table") then return end
     return data.focus.Quest.Id, "quest"
 end
 
 function strategies.wowhead.GetQuestFromQuestieFrame(data)
-    if not ((IsClassic() or IsMop()) and CheckFrameName("QuestieFrame%d+", data)) then return end
+    if not ((IsClassic() or IsBCC() or IsMop()) and CheckFrameName("QuestieFrame%d+", data)) then return end
     if data.focus.data.QuestData then return data.focus.data.QuestData.Id, "quest" end
     if data.focus.data.npcData then return data.focus.data.npcData.id, "npc" end
 end
@@ -350,7 +350,7 @@ end
 
 
 function strategies.wowhead.GetItemFromAuctionHouseClassic(data)
-    if not (IsClassic() or IsMop()) then return end
+    if not (IsClassic() or IsBCC() or IsMop()) then return end
     if not data.focus.itemIndex or (not data.focus.GetParent and not data.focus:GetParent().itemIndex) then return end
     local index = data.focus.itemIndex or data.focus:GetParent().itemIndex
     local link = GetAuctionItemLink("list", index)

--- a/WowheadQuickLink_TBC.toc
+++ b/WowheadQuickLink_TBC.toc
@@ -1,0 +1,13 @@
+## Interface: 20505
+## Version: 2.16.10
+## Title: Wowhead Quick Link
+## Notes: Mouse over and press CTRL-C on (almost) anything to generate a Wowhead link.
+## Author: Blur
+## SavedVariables: WowheadQuickLinkCfg
+## X-Curse-Project-ID: 326804
+
+WowheadQuickLinkConfig.xml
+WowheadQuickLinkConfig.lua
+
+WowheadQuickLinkStrategies.lua
+WowheadQuickLink.lua


### PR DESCRIPTION
Added WowheadQuickLink_TBC.toc, as Category-* TOC fields appear incompatible with the 20505 Classic/TBC client and prevent the addon from loading unless split into a separate TOC.

Fixed StaticPopup EditBox compatibility across Classic and Retail clients.

Added BCC WoW project ID handling.

Added TBC Wowhead URL support.

Tested on TBC Anniversary and Retail with BugGrabber enabled; no Lua errors observed.