### PR TITLE
feat: add #comments to URL

### DIFF
--- a/WowheadQuickLink.lua
+++ b/WowheadQuickLink.lua
@@ -1,15 +1,15 @@
 local addonName, nameSpace = ...
 if IsRetail() then
-    nameSpace.baseWowheadUrl = "https://%swowhead.com/%s=%s%s"
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/%s=%s%s#comments"
 end
 if IsClassic() then
-    nameSpace.baseWowheadUrl = "https://%swowhead.com/classic/%s=%s%s"
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/classic/%s=%s%s#comments"
 end
 if IsBCC() then
-    nameSpace.baseWowheadUrl = "https://%swowhead.com/tbc/%s=%s%s"
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/tbc/%s=%s%s#comments"
 end
 if IsMop() then
-    nameSpace.baseWowheadUrl = "https://%swowhead.com/mop-classic/%s=%s%s"
+    nameSpace.baseWowheadUrl = "https://%swowhead.com/mop-classic/%s=%s%s#comments"
 end
 
 nameSpace.baseWowheadAzEsUrl = "https://%swowhead.com/azerite-essence/%s%s"


### PR DESCRIPTION
99% of the time that you want to look at an item via wowhead, you will want to look at the comments anyway.
Now the '#comments' is automatically added to the URL so you do not have to scroll down anymore.